### PR TITLE
Add support for more OSes/arches/compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,16 @@ BIN := avs2yuv
 
 CC := $(CC)
 
-CCFLAGS := -I. -std=gnu99 -Wall -O3 -msse2 -mfpmath=sse -ffast-math -fno-math-errno -flto -fomit-frame-pointer
+CCFLAGS := -I. -std=gnu99 -Wall -O3 -ffast-math -fno-math-errno -flto -fomit-frame-pointer
 LDFLAGS := -Wl,--no-as-needed
+
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),i686)
+	CCFLAGS += -msse2 -mfpmath=sse
+endif
+ifeq ($(UNAME_M),x86_64)
+	CCFLAGS += -msse2 -mfpmath=sse
+endif
 
 ifeq (${OS},Windows_NT)
 	CCFLAGS += -I"${AVISYNTH_SDK_PATH}\include"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ OBJECTS := avs2yuv.o
 BIN := avs2yuv
 
 CCFLAGS := -I. -std=gnu99 -Wall -O3 -ffast-math -fno-math-errno -fomit-frame-pointer
-LDFLAGS := -Wl,--no-as-needed
+UNAME_S := $(shell uname -s)
+ifneq ($(UNAME_S),Darwin)
+	LDFLAGS := -Wl,--no-as-needed
+endif
 
 UNAME_M := $(shell uname -m)
 ifeq ($(UNAME_M),i686)
@@ -19,7 +22,6 @@ endif
 ifeq (${OS},Windows_NT)
 	CCFLAGS += -I"${AVISYNTH_SDK_PATH}\include"
 else
-UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Haiku)
 	LDFLAGS += -lroot
 else

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
 ifeq ($(UNAME_S),Haiku)
 	LDFLAGS += -lroot
 else
-	LDFLAGS += -ldl
+	LDFLAGS += -ldl -pthread
 endif
 	CCFLAGS += $(shell pkg-config --cflags avisynth)
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ endif
 OBJECTS := avs2yuv.o
 BIN := avs2yuv
 
-CC := $(CC)
-
-CCFLAGS := -I. -std=gnu99 -Wall -O3 -ffast-math -fno-math-errno -flto -fomit-frame-pointer
+CCFLAGS := -I. -std=gnu99 -Wall -O3 -ffast-math -fno-math-errno -fomit-frame-pointer
 LDFLAGS := -Wl,--no-as-needed
 
 UNAME_M := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,16 @@ endif
 OBJECTS := avs2yuv.o
 BIN := avs2yuv
 
-CC := gcc
+CC := $(CC)
 
 CCFLAGS := -I. -std=gnu99 -Wall -O3 -msse2 -mfpmath=sse -ffast-math -fno-math-errno -flto -fomit-frame-pointer
-LDFLAGS :=
+LDFLAGS := -Wl,--no-as-needed
 
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-	LDFLAGS += -ldl
-	CCFLAGS += -I/usr/local/include/avisynth
-else ifeq (${OS},Windows_NT)
+ifeq (${OS},Windows_NT)
 	CCFLAGS += -I"${AVISYNTH_SDK_PATH}\include"
+else
+	LDFLAGS += -ldl
+	CCFLAGS += $(shell pkg-config --cflags avisynth)
 endif
 all: $(BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ endif
 ifeq (${OS},Windows_NT)
 	CCFLAGS += -I"${AVISYNTH_SDK_PATH}\include"
 else
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Haiku)
+	LDFLAGS += -lroot
+else
 	LDFLAGS += -ldl
+endif
 	CCFLAGS += $(shell pkg-config --cflags avisynth)
 endif
 all: $(BIN)


### PR DESCRIPTION
Aside from Linux, this will allow avs2yuv to be built/used on the other POSIX OSes, to be built with GCC or Clang (whichever is the system default or overridden at compile-time), and on more CPU architectures than just x86(-64).

Tested on:
Ubuntu 20.10 (x86-64), Clang 11
macOS 11.0 Big Sur (x86-64), AppleClang
Haiku (x86-64), GCC 8.3
Ubuntu 20.04 (aarch64: Raspberry Pi 4B), GCC 9.3
Mac OS X 10.5 Leopard (ppc; iMac G5/970fx), GCC 4.8
Void Linux-ppc (ppc64/ppc64le; QEMU-emulated POWER9), GCC 9.3